### PR TITLE
Use gcmclient library for better features and compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - 2.6
   - 2.7
+  - 3.3
+  - 3.4
 install:
   - pip install coveralls
 script: make ci

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![PyPI Version][pypi-version-badge]][pypi-page]
 [![PyPI Downloads][pypi-downloads-badge]][pypi-page]
 
-Flask-GCM is a simple wrapper for the [`python-gcm`][python-gcm] library to be used with [Flask][flask] applications.
+Flask-GCM is a simple wrapper for the [`gcm-client`][gcm-client] library to be used with [Flask][flask] applications.
 
 ## Getting Started
 
@@ -55,7 +55,7 @@ def create_app():
     return app
 ```
 
-The `gcm` object can then be used as described in the [`python-gcm` docs][python-gcm-docs]
+The `gcm` object can then be used as described in the [`gcm-client` docs][gcm-client-docs]
 
 ## For Contributors
 
@@ -111,6 +111,6 @@ Contributions are always welcome! Please keep the following in mind when creatin
 [pypi-downloads-badge]: http://img.shields.io/pypi/dm/flask-gcm.svg
 [pypi-page]: https://pypi.python.org/pypi/flask-gcm
 [app-factories]: http://flask.pocoo.org/docs/0.10/patterns/appfactories/
-[python-gcm]: https://pypi.python.org/pypi/python-gcm
+[gcm-client]: https://pypi.python.org/pypi/gcm-client/
 [flask]: http://flask.pocoo.org/
-[python-gcm-docs]: https://github.com/geeknam/python-gcm#usage
+[gcm-client-docs]: http://gcm-client.readthedocs.org/en/latest/index.html

--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ Flask-GCM is a simple wrapper for the [`gcm-client`][gcm-client] library to be u
 
 ### Requirements
 
-* Python 2.6+
-
-Python3 is not yet supported, [but will be soon](https://github.com/MichiganLabs/flask-gcm/issues/1) (hopefully).
+* Python 2.6+ or Python 3.3+
 
 ### Installation
 

--- a/flask_gcm/__init__.py
+++ b/flask_gcm/__init__.py
@@ -2,29 +2,14 @@
 
 """Flask-GCM wrapper for python-gcm."""
 
-from gcm.gcm import (
+from gcmclient import (
     GCM as _GCM,
-    GCM_URL,
+    GCMAuthenticationError,
+    JSONMessage,
+    PlainTextMessage,
+    Result,
 )
-
-# Import exception classes into the flask_gcm package
-from gcm.gcm import (  # NOQA
-    GCMException,
-    GCMMalformedJsonException,
-    GCMConnectionException,
-    GCMAuthenticationException,
-    GCMTooManyRegIdsException,
-    GCMInvalidTtlException,
-    GCMMissingRegistrationException,
-    GCMMismatchSenderIdException,
-    GCMNotRegisteredException,
-    GCMMessageTooBigException,
-    GCMInvalidRegistrationException,
-    GCMUnavailableException,
-)
-
-# import other functions into flask_gcm package
-from gcm.gcm import group_response, urlencode_utf8  # NOQA
+from gcmclient.gcm import GCM_URL
 
 
 # Version info
@@ -37,19 +22,11 @@ VERSION = __project__ + '-' + __version__
 
 
 # Define what gets imported when using `from flask_gcm import *`
-__all__ = ('GCM',
-           'GCMException',
-           'GCMMalformedJsonException',
-           'GCMConnectionException',
-           'GCMAuthenticationException',
-           'GCMTooManyRegIdsException',
-           'GCMInvalidTtlException',
-           'GCMMissingRegistrationException',
-           'GCMMismatchSenderIdException',
-           'GCMNotRegisteredException',
-           'GCMMessageTooBigException',
-           'GCMInvalidRegistrationException',
-           'GCMUnavailableException',)
+__all__ = ('GCMAuthenticationError',
+           'JSONMessage',
+           'PlainTextMessage',
+           'GCM',
+           'Result')
 
 
 class GCM(_GCM):
@@ -62,19 +39,19 @@ class GCM(_GCM):
         if self.app:
             self.init_app(app)
 
-    def init_app(self, app):
+    def init_app(self, app, **kwargs):
         """Initialize the GCM object with flask app settings."""
         # Configure default GCM settings
         app.config.setdefault('GCM_URL', GCM_URL)
         app.config.setdefault('GCM_KEY', None)
-        app.config.setdefault('GCM_PROXY', None)
-        # The following is a limit hard coded into the python-gcm library:
+
+        # Hard limit in GCM API:
+        # http://developer.android.com/training/cloudsync/gcm.html
         app.config.setdefault('GCM_MAX_DEVICES_PER_REQUEST', 1000)
 
         # Configure GCM from app settings
-        self.url = app.config.get('GCM_URL')
+        self.url = app.config.get('GCM_URL') or GCM_URL
         self.api_key = app.config.get('GCM_KEY')
-        self.proxy = app.config.get('GCM_PROXY')
 
         # Register GCM on app extensions
         if not hasattr(app, 'extensions'):  # pragma: no cover
@@ -84,4 +61,4 @@ class GCM(_GCM):
 
         # init python-gcm object
         super(self.__class__, self).__init__(self.api_key, url=self.url,
-                                             proxy=self.proxy)
+                                             **kwargs)

--- a/flask_gcm/__init__.py
+++ b/flask_gcm/__init__.py
@@ -9,7 +9,7 @@ from gcmclient import (
     PlainTextMessage,
     Result,
 )
-from gcmclient.gcm import GCM_URL  # NOQA
+from gcmclient.gcm import GCM_URL
 
 
 # Version info
@@ -33,11 +33,11 @@ class GCM(_GCM):
 
     """Convenience wrapper class for GCM library."""
 
-    def __init__(self, app=None, api_key=None, url=GCM_URL):
+    def __init__(self, app=None, api_key=None, url=GCM_URL, **kwargs):
         """Initialize the GCM object with flask app settings."""
         self.app = app
         if self.app:
-            self.init_app(app)
+            self.init_app(app, **kwargs)
 
     def init_app(self, app, **kwargs):
         """Initialize the GCM object with flask app settings."""

--- a/flask_gcm/__init__.py
+++ b/flask_gcm/__init__.py
@@ -9,7 +9,7 @@ from gcmclient import (
     PlainTextMessage,
     Result,
 )
-from gcmclient.gcm import GCM_URL
+from gcmclient.gcm import GCM_URL  # NOQA
 
 
 # Version info

--- a/flask_gcm/test/conftest.py
+++ b/flask_gcm/test/conftest.py
@@ -4,13 +4,7 @@
 
 import pytest
 from flask import Flask
-
-
-@pytest.fixture(scope='function')
-def app():
-    """Create an instance of a Flask app."""
-    app = Flask(__name__)
-    return app
+from gcmclient.gcm import GCM_URL
 
 
 @pytest.fixture
@@ -18,6 +12,13 @@ def config():
     """Create a configuration class which can be loaded by a Flask app."""
     class Config:
         GCM_KEY = 'super secret'
-        GCM_URL = 'gcm url'
-        GCM_PROXY = 'gcm proxy'
+        GCM_URL = 'http://foobar.com'
     return Config
+
+
+@pytest.fixture(scope='function')
+def app(config):
+    """Create an instance of a Flask app."""
+    app = Flask(__name__)
+    app.config.from_object(config)
+    return app

--- a/flask_gcm/test/conftest.py
+++ b/flask_gcm/test/conftest.py
@@ -4,7 +4,6 @@
 
 import pytest
 from flask import Flask
-from gcmclient.gcm import GCM_URL
 
 
 @pytest.fixture

--- a/flask_gcm/test/test_flask_gcm.py
+++ b/flask_gcm/test/test_flask_gcm.py
@@ -2,12 +2,12 @@
 
 """Tests for Flask-GCM package"""
 
-from flask.ext.gcm import GCM
-from gcm.gcm import GCM_URL
+from flask.ext.gcm import GCM, GCM_URL
 
 
 class TestFlaskGCM:
     def test_create_new_gcm(self, app):
+        app.config['GCM_URL'] = None
         gcm = GCM(app)
 
         # If not specified, should use defalult URL from python-gcm
@@ -17,13 +17,11 @@ class TestFlaskGCM:
         assert gcm.app == app
         assert app.extensions['gcm'] == gcm
 
-    def test_create_new_gcm_copies_settings(self, app, config):
-        app.config.from_object(config)
+    def test_create_new_gcm_copies_settings(self, app):
         gcm = GCM(app)
 
         assert gcm.api_key == app.config['GCM_KEY']
         assert gcm.url == app.config['GCM_URL']
-        assert gcm.proxy == app.config['GCM_PROXY']
 
     def test_create_gcm_with_app_factory(self, app):
         gcm = GCM()
@@ -32,16 +30,14 @@ class TestFlaskGCM:
         # If app object is not passed to constructor, the extension should
         # not store it.
         assert gcm.app is None
-
         gcm.init_app(app)
+        assert gcm.app is None
 
         assert app.extensions['gcm'] == gcm
 
-    def test_create_gcm_with_app_factory_copies_settings(self, app, config):
-        app.config.from_object(config)
+    def test_create_gcm_with_app_factory_copies_settings(self, app):
         gcm = GCM()
         gcm.init_app(app)
 
         assert gcm.api_key == app.config['GCM_KEY']
         assert gcm.url == app.config['GCM_URL']
-        assert gcm.proxy == app.config['GCM_PROXY']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-python-gcm==0.1.5
+gcm-client==0.1.4
 Flask


### PR DESCRIPTION
gcmclient:
- Supports Python3+
- Handles success returns from GCM api, where python-gcm doesnt (geeknam/python-gcm#25)
- Uses the `requests` library instead of `urllib2`
- Has a better internal API in general
